### PR TITLE
Fixed: Lidarr Config Path

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -283,7 +283,7 @@ Sabnzbd en NZBget API keys invullen, voor alle applicaties
 sed -i 's/^  <ApiKey>.*/  <ApiKey>'\$radapi'<\/ApiKey>/' /root/.config/Radarr/config.xml
 
 ## lidarr
-sed -i 's/^  <ApiKey>.*/  <ApiKey>'\$lidapi'<\/ApiKey>/' /home/openflixr/.config/Lidarr/config.xml
+sed -i 's/^  <ApiKey>.*/  <ApiKey>'\$lidapi'<\/ApiKey>/' /root/.config/Lidarr/config.xml
 
 ## lazylibrarian
 crudini --set /opt/LazyLibrarian/lazylibrarian.ini SABnzbd sab_apikey \$sabapi


### PR DESCRIPTION
Current config settings cause Lidarr to throw `Access to the path "/home/openflixr/.config/Lidarr/config.xml" is denied.` which causes boot loop of Lidarr. 

Not really sure if this is the only thing that needs changing, But seems it was made different than Sonarr and Radarr for some reason